### PR TITLE
feat: se agregó la funcionalidad de cargar los planes/proyectos de interés asociados a una unidad

### DIFF
--- a/src/periodo-seguimiento/dto/periodo-seguimiento.dto.ts
+++ b/src/periodo-seguimiento/dto/periodo-seguimiento.dto.ts
@@ -16,15 +16,14 @@ export class PeriodoSeguimientoDto {
     @ApiProperty()
     tipo_seguimiento_id: String;
 
-
     @ApiProperty()
     activo: boolean;
 
     @ApiProperty()
-    unidades_interes: String;
+    unidades_interes: string;
 
     @ApiProperty()
-    planes_interes: String;
+    planes_interes: string;
 
     @ApiProperty()
     readonly fecha_creacion: Date;

--- a/src/periodo-seguimiento/periodo-seguimiento.controller.ts
+++ b/src/periodo-seguimiento/periodo-seguimiento.controller.ts
@@ -57,6 +57,21 @@ export class PeriodoSeguimientoController {
       });
   }
 
+  @Get('buscar-unidad/:unidadId')
+  // @ApiParam({ name: 'unidadId', description: 'ID de la unidad a buscar' })
+  async buscarRegistrosPorUnidad(@Res() res, @Param('unidadId') unidadId: string) {
+    const registrosEncontrados = await this.periodoSeguimientoService.buscarRegistrosPorUnidadInteres(unidadId);
+    if (!registrosEncontrados || registrosEncontrados.length === 0) throw new NotFoundException("not found resource")
+
+    res.status(HttpStatus.OK).json(
+      {
+        Data: registrosEncontrados ? registrosEncontrados : null,
+        Message: "Request succesfull",
+        Status: "200",
+        Success: true
+      });
+  }
+
   @Put('/:id')
   async put(@Res() res, @Param('id') id: string, @Body() periodoSeguimientoDto: PeriodoSeguimientoDto) {
 

--- a/src/periodo-seguimiento/periodo-seguimiento.service.ts
+++ b/src/periodo-seguimiento/periodo-seguimiento.service.ts
@@ -41,7 +41,19 @@ export class PeriodoSeguimientoService {
     } catch (error) {
       return null;
     };
+  }
 
+  async buscarRegistrosPorUnidadInteres(unidadId: string) {
+    try {
+      const registrosEncontrados = await this.periodoSeguimientoModel.find({
+        unidades_interes: new RegExp(`.*"Id":${unidadId}.*`),
+        activo: true,
+        planes_interes: { $exists: true, $ne: null},
+      }).exec();
+      return registrosEncontrados;
+    } catch (error) {
+      return null;
+    }
   }
 
   async put(id: string, PeriodoSeguimientoDto: PeriodoSeguimientoDto): Promise<PeriodoSeguimiento> {

--- a/src/periodo-seguimiento/schemas/periodo-seguimiento.schema.ts
+++ b/src/periodo-seguimiento/schemas/periodo-seguimiento.schema.ts
@@ -24,10 +24,10 @@ export class PeriodoSeguimiento extends Document {
     activo: boolean;
 
     @Prop({ required: true })
-    unidades_interes: String;
+    unidades_interes: string;
 
     @Prop({ required: true })
-    planes_interes: String;
+    planes_interes: string;
 
     @Prop({ required: true })
     fecha_creacion: Date;

--- a/swagger.json
+++ b/swagger.json
@@ -2056,6 +2056,29 @@
                 ]
             }
         },
+        "/periodo-seguimiento/buscar-unidad/{unidadId}": {
+            "get": {
+                "operationId": "PeriodoSeguimientoController_buscarRegistrosPorUnidad",
+                "parameters": [
+                    {
+                        "name": "unidadId",
+                        "required": true,
+                        "in": "path",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": ""
+                    }
+                },
+                "tags": [
+                    "periodo-seguimiento"
+                ]
+            }
+        },
         "/fuentes-apropiacion": {
             "post": {
                 "operationId": "FuentesApropiacionController_post",


### PR DESCRIPTION
- Se creó un método en el **servicio** de **_periodo_seguimiento_** para obtener los planes/proyectos de interés asociados a una unidad desde la base de datos en **MongoDB**.
- Se modificó el **controlador** de **_periodo-seguimiento_** para agregar una nueva petición tipo **Get** para poder acceder a los planes/proyectos de interés asociados a una unidad.