### PR TITLE
feat: se agregó el campo usuario_modificacion a periodo-seguimiento

### DIFF
--- a/src/periodo-seguimiento/dto/periodo-seguimiento.dto.ts
+++ b/src/periodo-seguimiento/dto/periodo-seguimiento.dto.ts
@@ -26,6 +26,9 @@ export class PeriodoSeguimientoDto {
     planes_interes: string;
 
     @ApiProperty()
+    usuario_modificacion: string;
+
+    @ApiProperty()
     readonly fecha_creacion: Date;
 
     @ApiProperty()

--- a/src/periodo-seguimiento/schemas/periodo-seguimiento.schema.ts
+++ b/src/periodo-seguimiento/schemas/periodo-seguimiento.schema.ts
@@ -29,6 +29,9 @@ export class PeriodoSeguimiento extends Document {
     @Prop({ required: true })
     planes_interes: string;
 
+    @Prop({ required: false })
+    usuario_modificacion: string;
+
     @Prop({ required: true })
     fecha_creacion: Date;
 

--- a/swagger-2.json
+++ b/swagger-2.json
@@ -2604,6 +2604,9 @@
         },
         "unidades_interes": {
           "type": "string"
+        },
+        "usuario_modificacion": {
+          "type": "string"
         }
       },
       "required": [
@@ -2614,6 +2617,7 @@
         "activo",
         "unidades_interes",
         "planes_interes",
+        "usuario_modificacion",
         "fecha_creacion",
         "fecha_modificacion"
       ],
@@ -2867,6 +2871,9 @@
         },
         "padre": {
           "type": "string"
+        },
+        "ref": {
+          "type": "string"
         }
       },
       "required": [
@@ -2876,6 +2883,7 @@
         "hijos",
         "activo",
         "bandera_tabla",
+        "ref",
         "fecha_creacion",
         "fecha_modificacion"
       ],

--- a/swagger.json
+++ b/swagger.json
@@ -3111,6 +3111,9 @@
                     "planes_interes": {
                         "type": "string"
                     },
+                    "usuario_modificacion": {
+                        "type": "string"
+                    },
                     "fecha_creacion": {
                         "format": "date-time",
                         "type": "string"
@@ -3128,6 +3131,7 @@
                     "activo",
                     "unidades_interes",
                     "planes_interes",
+                    "usuario_modificacion",
                     "fecha_creacion",
                     "fecha_modificacion"
                 ]


### PR DESCRIPTION
- Se agregó el campo usuario_modificacion a periodo-seguimiento para el requerimiento de visualización de usuarios que habilitan las fechas de formulación y seguimiento.