### PR TITLE
feat: lectura fechas seguimiento

### DIFF
--- a/src/periodo-seguimiento/dto/periodo-seguimiento.dto.ts
+++ b/src/periodo-seguimiento/dto/periodo-seguimiento.dto.ts
@@ -26,6 +26,9 @@ export class PeriodoSeguimientoDto {
     planes_interes: string;
 
     @ApiProperty()
+    nueva_estructura: boolean;
+
+    @ApiProperty()
     usuario_modificacion: string;
 
     @ApiProperty()

--- a/src/periodo-seguimiento/periodo-seguimiento.service.ts
+++ b/src/periodo-seguimiento/periodo-seguimiento.service.ts
@@ -66,6 +66,7 @@ export class PeriodoSeguimientoService {
     if(data.unidades_interes){
       var unidades_interes = JSON.parse(data.unidades_interes)
       var unidades = unidades_interes.map((unidad) => JSON.stringify(unidad));
+      var unidad = unidades_interes[0];
     }    
     if(data.planes_interes) {
       var planes_interes = JSON.parse(data.planes_interes)
@@ -74,16 +75,16 @@ export class PeriodoSeguimientoService {
     }
     
     if(caso === 1) { // Busca el registro por periodo y unidades
-      condiciones.unidades_interes = { $in: unidades.map((u) => new RegExp(u, 'i')) }; // Utilizando expresiones regulares para la comparación
-      condiciones.planes_interes = { $regex: new RegExp(`"${plan._id}"`), $options: 'i' };     // Esto hace la búsqueda más flexible y no sensible a mayúsculas/minúsculas
+      condiciones.unidades_interes = { $in: unidades.map((u) => new RegExp(u, 'i')) };        // Utilizando expresiones regulares para la comparación
+      condiciones.planes_interes = { $regex: new RegExp(`"${plan._id}"`), $options: 'i' };    // Esto hace la búsqueda más flexible y no sensible a mayúsculas/minúsculas
       registros = await this.periodoSeguimientoModel.find(condiciones).exec();
     } else if(caso === 2) { // Busca el registro por periodo, fecha_inicio y fecha_fin
-      condiciones.planes_interes = { $regex: new RegExp(`"${plan._id}"`), $options: 'i' };     // Esto hace la búsqueda más flexible y no sensible a mayúsculas/minúsculas
+      condiciones.planes_interes = { $regex: new RegExp(`"${plan._id}"`), $options: 'i' };
       condiciones.fecha_inicio = data.fecha_inicio;
       condiciones.fecha_fin = data.fecha_fin;
       registros = await this.periodoSeguimientoModel.find(condiciones).exec();
     } else if (caso === 3 ) { // Busca el registro que permita la formulación de un plan para una unidad específica
-      condiciones.unidades_interes = { $in: unidades.map((u) => new RegExp(u, 'i')) }; // Utilizando expresiones regulares para la comparación
+      condiciones.unidades_interes = { $in: unidades.map((u) => new RegExp(u, 'i')) };
       if (plan) {
         condiciones.planes_interes = { $regex: new RegExp(`"${plan._id}"`), $options: 'i' };
       }
@@ -98,7 +99,11 @@ export class PeriodoSeguimientoService {
         registros = [];
       }
     } else if (caso === 7) { // Filtro de plan/proyecto por _id
-      condiciones.planes_interes = { $regex: new RegExp(`"${plan._id}"`), $options: 'i' };     // Esto hace la búsqueda más flexible y no sensible a mayúsculas/minúsculas
+      condiciones.planes_interes = { $regex: new RegExp(`"${plan._id}"`), $options: 'i' };
+      condiciones.unidades_interes = {
+        $regex: new RegExp(`"Id":${unidad.Id}.*"${unidad.Nombre}"`),
+        $options: 'i'
+      };
       registros = await this.periodoSeguimientoModel.find(condiciones).exec();
     }
     console.log('Registros encontrados: ', registros);

--- a/src/periodo-seguimiento/periodo-seguimiento.service.ts
+++ b/src/periodo-seguimiento/periodo-seguimiento.service.ts
@@ -18,6 +18,7 @@ export class PeriodoSeguimientoService {
   async post(PeriodoSeguimientoDto: PeriodoSeguimientoDto): Promise<PeriodoSeguimiento> {
     try {
       const PeriodoSeguimiento = new this.periodoSeguimientoModel(PeriodoSeguimientoDto);
+      PeriodoSeguimiento.nueva_estructura = true;
       PeriodoSeguimiento.fecha_creacion = new Date();
       PeriodoSeguimiento.fecha_modificacion = new Date();
       PeriodoSeguimiento.activo = true;
@@ -105,6 +106,9 @@ export class PeriodoSeguimientoService {
         $options: 'i'
       };
       registros = await this.periodoSeguimientoModel.find(condiciones).exec();
+    } else if (caso === 8) { // Caso para consultar registros de periodo-seguimiento antiguos
+      condiciones.nueva_estructura = null;
+      registros = await this.periodoSeguimientoModel.find(condiciones).exec();
     }
     console.log('Registros encontrados: ', registros);
     return registros;
@@ -114,6 +118,7 @@ export class PeriodoSeguimientoService {
   async put(id: string, PeriodoSeguimientoDto: PeriodoSeguimientoDto): Promise<PeriodoSeguimiento> {
     try {
       PeriodoSeguimientoDto.fecha_modificacion = new Date();
+      PeriodoSeguimientoDto.nueva_estructura = true;
       await this.periodoSeguimientoModel.validate(PeriodoSeguimientoDto);
       await this.periodoSeguimientoModel.findByIdAndUpdate(id, PeriodoSeguimientoDto, { new: true }).exec();
       return await this.periodoSeguimientoModel.findById(id).exec();

--- a/src/periodo-seguimiento/schemas/periodo-seguimiento.schema.ts
+++ b/src/periodo-seguimiento/schemas/periodo-seguimiento.schema.ts
@@ -30,6 +30,9 @@ export class PeriodoSeguimiento extends Document {
     planes_interes: string;
 
     @Prop({ required: false })
+    nueva_estructura: boolean;
+
+    @Prop({ required: false })
     usuario_modificacion: string;
 
     @Prop({ required: true })

--- a/swagger.json
+++ b/swagger.json
@@ -3111,6 +3111,9 @@
                     "planes_interes": {
                         "type": "string"
                     },
+                    "nueva_estructura": {
+                        "type": "boolean"
+                    },
                     "usuario_modificacion": {
                         "type": "string"
                     },
@@ -3131,6 +3134,7 @@
                     "activo",
                     "unidades_interes",
                     "planes_interes",
+                    "nueva_estructura",
                     "usuario_modificacion",
                     "fecha_creacion",
                     "fecha_modificacion"


### PR DESCRIPTION
- Se creó el nuevo parámetro en el schema de periodo-seguimiento llamado nueva_estructura de tipo booleano (Siempre estará en true para los nuevos registros ingresados a la base de datos).
- Se modificó el DTO para incluir el parámetro mencionado anteriormente
- Se creó el nuevo caso para buscar los registros de periodo-seguimiento antiguos (aquellos que no tienen la nueva_estructura)