### PR TITLE
feat: lectura fechas seguimiento

### DIFF
--- a/src/periodo-seguimiento/dto/periodo-seguimiento.dto.ts
+++ b/src/periodo-seguimiento/dto/periodo-seguimiento.dto.ts
@@ -26,6 +26,9 @@ export class PeriodoSeguimientoDto {
     planes_interes: string;
 
     @ApiProperty()
+    nueva_estructura: boolean;
+
+    @ApiProperty()
     usuario_modificacion: string;
 
     @ApiProperty()

--- a/src/periodo-seguimiento/schemas/periodo-seguimiento.schema.ts
+++ b/src/periodo-seguimiento/schemas/periodo-seguimiento.schema.ts
@@ -30,6 +30,9 @@ export class PeriodoSeguimiento extends Document {
     planes_interes: string;
 
     @Prop({ required: false })
+    nueva_estructura: boolean;
+
+    @Prop({ required: false })
     usuario_modificacion: string;
 
     @Prop({ required: true })

--- a/swagger.json
+++ b/swagger.json
@@ -3111,6 +3111,9 @@
                     "planes_interes": {
                         "type": "string"
                     },
+                    "nueva_estructura": {
+                        "type": "boolean"
+                    },
                     "usuario_modificacion": {
                         "type": "string"
                     },
@@ -3131,6 +3134,7 @@
                     "activo",
                     "unidades_interes",
                     "planes_interes",
+                    "nueva_estructura",
                     "usuario_modificacion",
                     "fecha_creacion",
                     "fecha_modificacion"


### PR DESCRIPTION
- Se creó el nuevo parámetro en el schema de periodo-seguimiento llamado nueva_estructura de tipo booleano (Siempre estará en true para los nuevos registros ingresados a la base de datos).
- Se modificó el DTO para incluir el parámetro mencionado anteriormente
- Se creó el nuevo caso para buscar los registros de periodo-seguimiento antiguos (aquellos que no tienen la nueva_estructura)